### PR TITLE
Create course outline for Azure for SREs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,35 @@
+# Azure for SREs 🚀
+
+A practical, real-world course focused on running reliable workloads on Microsoft Azure.This comprehensive course is designed for aspiring and junior Site Reliability Engineers (SREs) who want to master Microsoft Azure fundamentals and SRE best practices. Through hands-on labs, real-world projects, and practical demos, learners will gain the skills needed to build, monitor, automate, and secure cloud-native systems on Azure.
+
+## Who Should Take This Course?
+- Beginners interested in cloud computing and Azure
+- Junior SREs, DevOps engineers, and IT professionals
+- Students and career changers seeking hands-on Azure experience
+
+## What You'll Learn
+- SRE fundamentals applied to Azure        
+- AKS reliability patterns
+- Monitoring, alerting, and incident response
+- Infrastructure as Code with Terraform & Bicep
+- Real-world failure scenarios
+
+## Course Structure
+- Module 1: Introduction to Azure & SRE
+- Module 2: Core Azure Services for SREs
+- Module 3: Observability & Monitoring
+- Module 4: Keeping Systems Reliable
+- Module 5: Automation & DevOps for Beginners
+- Module 6: Security & Cost Management
+- Module 7: Hands-On Projects (Guided Labs)
+- Module 8: Career Prep, Best Practices & Conclusion
+
+Advance Topics - Azure Services Specific
+1. [Azure Automation Account](https://github.com/Abhiram-Mangde/Course-Azure-for-SREs/tree/main/Azure%20Automation%20Account)
+2. [Azure Entra Id](https://github.com/Abhiram-Mangde/Course-Azure-for-SREs/tree/main/Azure%20Entra%20Id)
+3. [Azure Kubernetes Service](https://github.com/Abhiram-Mangde/Course-Azure-for-SREs/tree/main/Azure%20Kubernetes%20Service)
+4. [Azure Monitor](https://github.com/Abhiram-Mangde/Course-Azure-for-SREs/tree/main/Azure%20Monitor)
+
+## Community
+- Ask questions in [GitHub Discussions]((https://github.com/Abhiram-Mangde/Course-Azure-for-SREs/discussions)
+- Contribute via Pull Requests [Contributing Guidelines](https://github.com/Abhiram-Mangde/Course-Azure-for-SREs/blob/main/CONTRIBUTING.md)


### PR DESCRIPTION
Added a comprehensive course outline for Azure aimed at aspiring and junior Site Reliability Engineers, including learning objectives and community engagement.