### PR TITLE
Potential fix for code scanning alert no. 3: Clear-text logging of sensitive information

### DIFF
--- a/Sample-ProjectFiles/scripts/access_secrets_keyvault_script.py
+++ b/Sample-ProjectFiles/scripts/access_secrets_keyvault_script.py
@@ -38,7 +38,7 @@ client = SecretClient(vault_url=KV_URI, credential=credential)
 # Retrieve the secret
 # ----------------------------------------------------
 try:
-    print(f"Retrieving secret '{SECRET_NAME}' from Key Vault...")
+    print("Retrieving secret from Key Vault...")
     secret = client.get_secret(SECRET_NAME)
     print("Secret retrieved successfully!")
     print(f"Secret Value: {secret.value}")  # For demo only — do NOT print in production


### PR DESCRIPTION
Potential fix for [https://github.com/Abhiram-Mangde/Course-Azure-for-SREs/security/code-scanning/3](https://github.com/Abhiram-Mangde/Course-Azure-for-SREs/security/code-scanning/3)

In general, to fix clear‑text logging issues you should avoid writing sensitive values or identifiers directly to logs. Either remove such logging entirely, or replace it with a version that omits or masks the sensitive part (for example, logging only that a secret is being retrieved, or logging a fixed label instead of the actual environment‑derived value).

For this script, the best minimal fix is to stop interpolating `SECRET_NAME` (which is tainted from the environment) into the log message. We can still keep a useful log line that indicates that a secret retrieval is in progress, but without echoing the secret identifier. Specifically, on line 41 in `Sample-ProjectFiles/scripts/access_secrets_keyvault_script.py`, we should replace:

```python
print(f"Retrieving secret '{SECRET_NAME}' from Key Vault...")
```

with a neutral message like:

```python
print("Retrieving secret from Key Vault...")
```

This preserves all behavior related to actually retrieving and using the secret, while eliminating the clear‑text logging of the tainted value. No additional imports, methods, or definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
