### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -11,6 +11,8 @@ jobs:
     name: CD - Deploy Course Content
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    permissions:
+      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/Abhiram-Mangde/Course-Azure-for-SREs/security/code-scanning/2](https://github.com/Abhiram-Mangde/Course-Azure-for-SREs/security/code-scanning/2)

In general, the fix is to explicitly specify a `permissions:` block to scope down the GITHUB_TOKEN instead of relying on repository defaults. This can be done either at the workflow root (applies to all jobs) or at the individual job; here we can add it to the `deploy` job to minimally change scope.

For this specific workflow, the job checks out the repo and runs deployment and notification shell commands, with no evidence of needing to push commits, open PRs, or modify issues. Therefore, the safest minimal permission is `contents: read`. We will modify `.github/workflows/cd.yml` by adding a `permissions:` section under `jobs.deploy`, right below the `if:` line, like:

```yaml
    permissions:
      contents: read
```

This does not change any existing functionality: `actions/checkout@v4` only needs read access to contents. No additional imports, methods, or definitions are required since this is purely a workflow YAML change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
