### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: Course Content CI # Name of the GitHub Actions workflow
 
+permissions:
+  contents: read
+
 on:
   push: # Name of the GitHub Actions workflow
     paths:


### PR DESCRIPTION
Potential fix for [https://github.com/Abhiram-Mangde/Course-Azure-for-SREs/security/code-scanning/1](https://github.com/Abhiram-Mangde/Course-Azure-for-SREs/security/code-scanning/1)

To fix the problem, we should explicitly declare a minimal `permissions` block so the `GITHUB_TOKEN` only has read access to repository contents. Since there is only one job and it doesn’t perform any write operations via GitHub APIs, the simplest and safest fix is to add `permissions: contents: read` at the workflow root level, just under `name:` (or at the same level as `on:`). This applies to all jobs that don’t override `permissions` and avoids any behavior change in the existing steps, which only read code and run local tools.

Concretely, edit `.github/workflows/ci.yml` near the top: after line 1 (`name: Course Content CI # ...`), insert a `permissions:` block with `contents: read` indented at the root level. No imports or additional methods are required; it is purely a YAML configuration change. No changes are needed inside the `jobs:` section because the root-level `permissions` will automatically apply to `content-checks`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
