### PR TITLE
Potential fix for code scanning alert no. 5: DOM text reinterpreted as HTML

### DIFF
--- a/docs/chatbot.js
+++ b/docs/chatbot.js
@@ -139,14 +139,26 @@ function appendMessage(text, className) {
   const messageDiv = document.createElement("div");
   messageDiv.className = className;
 
-  // Support clickable links
+  // Support clickable links without interpreting text as HTML
   if (text.includes("Read more:")) {
     const parts = text.split("Read more:");
-    messageDiv.innerHTML = `
-      ${parts[0]}
-      <br><br>
-      <a href="${repoBase}${parts[1].trim()}" target="_blank" rel="noopener noreferrer">Read full page →</a>
-    `;
+
+    // Add the preview text safely
+    const previewSpan = document.createElement("span");
+    previewSpan.innerText = parts[0];
+    messageDiv.appendChild(previewSpan);
+
+    // Add line breaks
+    messageDiv.appendChild(document.createElement("br"));
+    messageDiv.appendChild(document.createElement("br"));
+
+    // Add the "Read full page" link
+    const link = document.createElement("a");
+    link.href = repoBase + parts[1].trim();
+    link.target = "_blank";
+    link.rel = "noopener noreferrer";
+    link.textContent = "Read full page \u2192";
+    messageDiv.appendChild(link);
   } else {
     messageDiv.innerText = text;
   }


### PR DESCRIPTION
Potential fix for [https://github.com/Abhiram-Mangde/Course-Azure-for-SREs/security/code-scanning/5](https://github.com/Abhiram-Mangde/Course-Azure-for-SREs/security/code-scanning/5)

In general, the fix is to ensure that untrusted text is never interpolated directly into `innerHTML` without proper escaping/sanitization, and that any HTML structure we need (like the "Read full page" link) is built using DOM APIs (e.g., `createElement`, `innerText`, `textContent`) rather than raw template strings.

The best targeted fix here is to remove the use of `innerHTML` in `appendMessage` and instead construct the "Read more" variant message using DOM nodes. We can still split on `"Read more:"` to detect the pattern, but we should: (1) put `parts[0]` into a text node (or `innerText`) so that any `<script>` or other HTML tags are escaped, and (2) create an `<a>` element for the link, setting its `href` and `textContent` explicitly. That preserves current functionality (a preview + a clickable "Read full page" link) without ever interpreting user-controlled text as HTML. All changes are confined to `docs/chatbot.js` within the `appendMessage` function.

Concretely, in `docs/chatbot.js` around lines 142–152, replace the `innerHTML` block with code that:
- Creates a text node or uses `innerText` for `parts[0]`.
- Inserts a `<br>`/line break via DOM elements instead of `<br><br>` HTML.
- Creates an `<a>` element, sets `href` to `${repoBase}${parts[1].trim()}`, sets `target` and `rel` as before, and sets `textContent` (not `innerHTML`) to `"Read full page →"`.

No new imports or external libraries are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
