### PR TITLE
Potential fix for code scanning alert no. 6: DOM text reinterpreted as HTML

### DIFF
--- a/docs/chatbot.js
+++ b/docs/chatbot.js
@@ -154,7 +154,17 @@ function appendMessage(text, className) {
 
     // Add the "Read full page" link
     const link = document.createElement("a");
-    link.href = repoBase + parts[1].trim();
+    const rawPath = parts[1].trim();
+    // Basic validation to keep the link as a relative path under repoBase
+    // Disallow schemes ("://"), whitespace, and control characters
+    const safePathPattern = /^[^\s\x00-\x1F\x7F]*$/;
+    let safePath = "";
+    if (safePathPattern.test(rawPath) && !rawPath.includes("://")) {
+      // Ensure the path starts with a single "/"
+      safePath = rawPath.startsWith("/") ? rawPath : "/" + rawPath;
+    }
+    // Fallback to repoBase if the path is not considered safe
+    link.href = safePath ? (repoBase + safePath) : repoBase;
     link.target = "_blank";
     link.rel = "noopener noreferrer";
     link.textContent = "Read full page \u2192";


### PR DESCRIPTION
Potential fix for [https://github.com/Abhiram-Mangde/Course-Azure-for-SREs/security/code-scanning/6](https://github.com/Abhiram-Mangde/Course-Azure-for-SREs/security/code-scanning/6)

In general, to fix this class of problem you must prevent untrusted DOM text from being interpreted in more powerful contexts (HTML, JavaScript, or unvalidated URLs). For URLs specifically, you should validate and normalize any untrusted component before assigning it to `href`: restrict to expected patterns (e.g., same‑site relative paths), reject dangerous schemes (`javascript:`, `data:`, etc.), and treat anything invalid as plain text or ignore it.

The best minimal fix here is to (1) extract and trim the untrusted URL suffix from `parts[1]`, (2) ensure it is treated as a relative path under `repoBase` (e.g., force a leading `/` and disallow control characters and whitespace), and (3) only assign it to `href` if it passes basic validation; otherwise, either omit the link or fall back to a safe default. This keeps all existing functionality (a clickable “Read full page →” link into your GitHub Pages content) while preventing arbitrary user‑controlled URLs or malformed values from being used.

Concretely, in `docs/chatbot.js`, within `appendMessage` where the link is built:

- Replace `link.href = repoBase + parts[1].trim();` with logic that:
  - Stores `parts[1].trim()` into a variable, e.g. `rawPath`.
  - Uses a regex to ensure `rawPath` is a relatively safe path (e.g. no whitespace, no control characters, no URL schemes like `://`).
  - Normalizes it to start with `/` (so it cannot change the hostname/base origin).
  - If it fails validation, sets `link.href` to `repoBase` only (or skips appending the link).

No new imports are necessary; plain JavaScript is enough. All changes stay within the shown `appendMessage` function.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
