### PR TITLE
Fix routing for Azure services

### DIFF
--- a/docs/_data/navigation.yml
+++ b/docs/_data/navigation.yml
@@ -116,19 +116,3 @@ tracks:
         url: /cicd-course/Module-4-Continuous-Delivery-Deployment/
       - title: Module 5 - YAML Pipelines
         url: /cicd-course/Module-5-Yaml-Pipelines/
-  - id: kql-observability
-    title: KQL for Observability
-    description: Learn Kusto Query Language for logs, metrics, and reliability diagnostics.
-    url: /kql-course/
-  - id: digital-twins
-    title: Azure Digital Twins
-    description: Learn DTDL, modeling, and digital twin architecture.
-    url: /dtdl-course/
-  - id: rag-systems
-    title: RAG Systems
-    description: Learn retrieval-augmented generation and knowledge-driven AI architectures.
-    url: /rag-course/
-  - id: cicd
-    title: CI/CD Pipelines
-    description: Learn automation and deployment pipelines on Azure.
-    url: /cicd-course/

--- a/docs/_includes/sidebar.html
+++ b/docs/_includes/sidebar.html
@@ -3,13 +3,17 @@
   <ul>
     {% assign current_track = nil %}
     {% for track in site.data.navigation.tracks %}
-      {% if track.url != '/' and page.url contains track.url %}
-        {% assign current_track = track %}
+      {% if track.url != '/' %}
+        {% assign prefix = page.url | slice: 0, track.url | size %}
+        {% if prefix == track.url %}
+          {% assign current_track = track %}
+        {% endif %}
       {% endif %}
     {% endfor %}
 
     {% for track in site.data.navigation.tracks %}
-      {% assign is_current = track.url != '/' and page.url contains track.url %}
+      {% assign prefix = page.url | slice: 0, track.url | size %}
+      {% assign is_current = track.url != '/' and prefix == track.url %}
       <li class="{% if is_current %}active{% endif %}">
         <a href="{{ track.url | relative_url }}">{{ track.title }}</a>
 

--- a/docs/azureservices.md
+++ b/docs/azureservices.md
@@ -1,6 +1,7 @@
 ---
 layout: page
 title: Azure Services
+permalink: /azureservices/
 ---
 
 <style>


### PR DESCRIPTION
Azure Service link on the header was not working 

Fixes applied
[azureservices.md](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/8b640eef5a/resources/app/out/vs/code/electron-browser/workbench/workbench.html)

Added permalink: /azureservices/
This fixes the Azure Hub header link 404 by matching the nav path to the actual page route.
[navigation.yml](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/8b640eef5a/resources/app/out/vs/code/electron-browser/workbench/workbench.html)

Removed duplicated course track entries
Cleaned the track list so only one entry per course exists
[sidebar.html](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/8b640eef5a/resources/app/out/vs/code/electron-browser/workbench/workbench.html)

Tightened course detection using exact prefix matching
Now the sidebar should only expand the currently selected track’s modules
Root cause
Azure Hub was 404 because [azureservices.md](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/8b640eef5a/resources/app/out/vs/code/electron-browser/workbench/workbench.html) did not expose /azureservices/ as a permalink.
The sidebar logic was still relying on loose contains matching and the nav data had stale duplicate track definitions.Fixes applied
[azureservices.md](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/8b640eef5a/resources/app/out/vs/code/electron-browser/workbench/workbench.html)

Added permalink: /azureservices/
This fixes the Azure Hub header link 404 by matching the nav path to the actual page route.
[navigation.yml](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/8b640eef5a/resources/app/out/vs/code/electron-browser/workbench/workbench.html)

Removed duplicated course track entries
Cleaned the track list so only one entry per course exists
[sidebar.html](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/8b640eef5a/resources/app/out/vs/code/electron-browser/workbench/workbench.html)

Tightened course detection using exact prefix matching
Now the sidebar should only expand the currently selected track’s modules
Root cause
Azure Hub was 404 because [azureservices.md](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/8b640eef5a/resources/app/out/vs/code/electron-browser/workbench/workbench.html) did not expose /azureservices/ as a permalink.
The sidebar logic was still relying on loose contains matching and the nav data had stale duplicate track definitions.